### PR TITLE
Add digits dataset visualization script

### DIFF
--- a/digits_display.py
+++ b/digits_display.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt
+from sklearn.datasets import load_digits
+import numpy as np
+
+# Load digits dataset
+digits = load_digits()
+
+# Plot first 10 images with labels
+fig, axes = plt.subplots(2, 5, figsize=(10, 4))
+for ax, img, label in zip(axes.flatten(), digits.images, digits.target):
+    ax.imshow(img, cmap='gray_r')
+    ax.set_title(f'Label: {label}')
+    ax.axis('off')
+plt.tight_layout()
+plt.savefig('sample_digits.png')
+plt.close()
+
+# Compute class distribution
+counts = np.bincount(digits.target, minlength=len(digits.target_names))
+
+# Print distribution
+for digit, count in enumerate(counts):
+    print(f"{digit}: {count}")
+
+# Plot distribution
+plt.figure(figsize=(6, 4))
+plt.bar(np.arange(len(counts)), counts, color='skyblue')
+plt.xlabel('Digit class')
+plt.ylabel('Count')
+plt.title('Class distribution in digits dataset')
+plt.xticks(np.arange(len(counts)))
+plt.tight_layout()
+plt.savefig('class_distribution.png')
+


### PR DESCRIPTION
## Summary
- add `digits_display.py` to load the sklearn digits dataset
- show sample images and plot the class distribution

## Testing
- `python -m py_compile digits_display.py`


------
https://chatgpt.com/codex/tasks/task_e_684801e4b8708327aecc6c2069fb655d