### PR TITLE
Add Dockerfile for ACP_train_2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install required Python packages
+RUN pip install --no-cache-dir numpy matplotlib scikit-learn
+
+# Copy the training script into the container
+COPY ACP_train_2.py /app/ACP_train_2.py
+
+# Use a non-interactive backend for matplotlib
+ENV MPLBACKEND=Agg
+
+# Run the training script by default
+CMD ["python", "ACP_train_2.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile to run `ACP_train_2.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68495ea8df208327bc9ff58d0c3775ef